### PR TITLE
Remove hardcoded `agg: "SUM"` in query

### DIFF
--- a/src/main/java/com/github/shmoli/kafka/connect/source/metricsapi/MetricsAPIHttpClient.java
+++ b/src/main/java/com/github/shmoli/kafka/connect/source/metricsapi/MetricsAPIHttpClient.java
@@ -217,7 +217,6 @@ public class MetricsAPIHttpClient {
         String query = String.format("{\n" +
                 "    \"aggregations\": [\n" +
                 "        {\n" +
-                "            \"agg\": \"SUM\",\n" +
                 "            \"metric\": \"%s\"\n" +
                 "        }\n" +
                 "    ],\n" +


### PR DESCRIPTION
Different metrics can have different required aggregations.
Hardcoding `agg: "SUM"` will cause query errors on metrics that require `MAX` aggregation like `io.confluent.kafka.server/cluster_link_mirror_topic_offset_lag`